### PR TITLE
Added init-script support for database starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ Usual use cases include:
     * [MSSQL](#MSSQL)
         * [Tests](#MSSQLTests)
         * [Local development](#MSSQLLocalDevelopment)
-        * [Docker image](#MSSQLDockerImage)
+        * [Docker image version](#MSSQLDockerImage)
+        * [Initialization script](#MSSQLInitScript)
     * [PostgreSQL](#PostgreSQL)
         * [Tests](#PostgreSQLTests)
         * [Local development](#PostgreSQLLocalDevelopment)
-        * [Docker image](#PostgreSQLDockerImage)
+        * [Docker image version](#PostgreSQLDockerImage)
+        * [Initialization script](#PostgreSQLInitScript)
     * [Redis](#Redis)
         * [Tests](#RedisTests)
         * [Local development](#RedisDevelopment)
-        * [Docker image](#RedisDockerImage)
+        * [Docker image version](#RedisDockerImage)
     * [Kafka](#Kafka)
         * [Automatic topic creation](#KafkaTopic)
         * [Tests](#KafkaTests)
@@ -34,14 +36,15 @@ Usual use cases include:
     * [RabbitMQ](#RabbitMq)
         * [Tests](#RabbitMqTests)
         * [Local development](#RabbitMqLocalDevelopment)
-        * [Docker image](#RabbitMqDockerImage)
+        * [Docker image version](#RabbitMqDockerImage)
     * [ClickHouse](#ClickHouse)
         * [Tests](#ClickHouseTests)
         * [Local development](#ClickHouseLocalDevelopment)
-        * [Docker image version](#ClickHouseDockerImageVersion)
+        * [Docker image version](#ClickHouseDockerImage)
+        * [Initialization script](#ClickHouseInitScript)
 
 <a name="Changelog"></a>
-##  Changelog
+## Changelog
 
 For changes check the [changelog](CHANGELOG.md).
 
@@ -147,6 +150,15 @@ To change the docker image used simply add the following property (e.g. in yaml)
 testcontainers.mssql.docker.image: mcr.microsoft.com/mssql/server:2017-CU12
 ```
 
+<a name="MSSQLInitScript"></a>
+#### Initialization script
+
+To add an SQL script with which the container will be initialized with add the following property (e.g. in yaml):
+
+```yaml
+testcontainers.mssql.init-script: db/init-script.sql
+```
+
 <a name="PostgreSQL"></a>
 ### PostgreSQL
 
@@ -220,7 +232,16 @@ spring:
 To change the docker image used simply add the following property (e.g. in yaml):
 
 ```yaml
-testcontainers.postgresql.docker.image: postgres:10
+testcontainers.postgresql.docker.image: postgres:15
+```
+
+<a name="PostgreSQLInitScript"></a>
+#### Initialization script
+
+To add an SQL script with which the container will be initialized with add the following property (e.g. in yaml):
+
+```yaml
+testcontainers.postgresql.init-script: db/init-script.sql
 ```
 
 <a name="Redis"></a>
@@ -501,7 +522,6 @@ Add the following profile:
 Before starting the application locally, activate development profile:
 
 ![profile.png](profile.png)
-<a name="ClickHouseDockerImageVersion"></a>
 
 and update your local configuration (e.g. application-development.yaml):
 
@@ -512,7 +532,7 @@ spring:
 ```
 In case your datasource configuration is different from default one you can provide custom configuration property path
 ```yaml
-    testcontainers.clickhouse.custom-path: "spring.datasource.clickhouse"
+testcontainers.clickhouse.custom-path: "spring.datasource.clickhouse"
 ```
 in this case your configuration would look like this
 
@@ -523,12 +543,22 @@ spring:
         jdbc-url: <host>:<port>
 ```
 
+<a name="ClickHouseDockerImage"></a>
 #### Docker image version
 
 To change the docker image used simply add the following property (e.g. in yaml):
 
 ```yaml
-testcontainers.clickhouse.docker.image: rabbitmq:latest
+testcontainers.clickhouse.docker.image: clickhouse:latest
+```
+
+<a name="ClickHouseInitScript"></a>
+#### Initialization script
+
+To add an SQL script with which the container will be initialized with add the following property (e.g. in yaml):
+
+```yaml
+testcontainers.clickhouse.init-script: db/init-script.sql
 ```
 
 ## <a name="Contributing"></a> Contributing

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/pom.xml
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
 	<artifactId>infobip-clickhouse-testcontainers-spring-boot-starter</artifactId>
 
 	<properties>
-		<clickhouse-jdbc.version>0.2.4</clickhouse-jdbc.version>
+		<clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
 	</properties>
 
 	<dependencies>
@@ -31,15 +31,16 @@
 			<artifactId>clickhouse</artifactId>
 			<version>${testcontainers.version}</version>
 		</dependency>
+
 		<dependency>
-			<groupId>ru.yandex.clickhouse</groupId>
+			<groupId>com.clickhouse</groupId>
 			<artifactId>clickhouse-jdbc</artifactId>
 			<version>${clickhouse-jdbc.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializer.java
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializer.java
@@ -21,6 +21,8 @@ public class ClickhouseContainerInitializer extends InitializerBase<ClickhouseCo
                                                        .map(ClickhouseContainerWrapper::new)
                                                        .orElseGet(ClickhouseContainerWrapper::new);
 
+        Optional.ofNullable(environment.getProperty("testcontainers.clickhouse.init-script")).ifPresent(container::withInitScript);
+
         resolveStaticPort(jdbcUrlValue, GENERIC_URL_WITH_PORT_GROUP_PATTERN)
             .ifPresent(staticPort -> bindPort(container, staticPort, ClickhouseContainerWrapper.HTTP_PORT));
 
@@ -28,8 +30,7 @@ public class ClickhouseContainerInitializer extends InitializerBase<ClickhouseCo
 
         String url = replaceHostAndPortPlaceholders(jdbcUrlValue, container, ClickhouseContainerWrapper.HTTP_PORT);
 
-        TestPropertyValues values = TestPropertyValues.of(
-            String.format("%s=%s", jdbcUrlPropertyPath, url));
+        TestPropertyValues values = TestPropertyValues.of(String.format("%s=%s", jdbcUrlPropertyPath, url));
         values.applyTo(applicationContext);
     }
 

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerWrapper.java
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerWrapper.java
@@ -7,7 +7,8 @@ public class ClickhouseContainerWrapper extends ClickHouseContainer {
     public ClickhouseContainerWrapper() {
     }
 
-    public ClickhouseContainerWrapper(String confluentPlatformVersion) {
-        super(confluentPlatformVersion);
+    public ClickhouseContainerWrapper(String image) {
+        super(image);
     }
+
 }

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializerTest.java
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializerTest.java
@@ -17,10 +17,10 @@ import org.springframework.test.context.TestConstructor;
 @SpringBootTest(classes = Main.class)
 class ClickhouseContainerInitializerTest {
 
-    DataSource dataSource;
+    private DataSource dataSource;
 
     @Test
-    void shouldCreateContainer()  {
+    void shouldCreateContainer() {
         //given
         JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 
@@ -30,4 +30,5 @@ class ClickhouseContainerInitializerTest {
         //then
         then(result).isEqualTo("1");
     }
+
 }

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializerWithInitScriptTest.java
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializerWithInitScriptTest.java
@@ -1,0 +1,34 @@
+package com.infobip.testcontainers.spring.clickhouse;
+
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@AllArgsConstructor
+@ActiveProfiles("init-script")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = Main.class)
+class ClickhouseContainerInitializerWithInitScriptTest {
+
+    private DataSource dataSource;
+
+    @Test
+    void shouldCreateContainer() {
+        //given
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+
+        //when
+        String result = jdbcTemplate.queryForObject("SELECT name FROM test_table WHERE id = 1", String.class);
+
+        //then
+        then(result).isEqualTo("Test");
+    }
+
+}

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializerWithStaticPortTest.java
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/ClickhouseContainerInitializerWithStaticPortTest.java
@@ -19,8 +19,8 @@ import org.springframework.test.context.TestConstructor;
 @SpringBootTest(classes = Main.class)
 class ClickhouseContainerInitializerWithStaticPortTest {
 
-    Environment environment;
-    DataSource dataSource;
+    private Environment environment;
+    private DataSource dataSource;
 
     @Test
     void shouldCreateContainerWithStaticPort() {

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/Main.java
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/clickhouse/Main.java
@@ -9,4 +9,5 @@ public class Main {
     public static void main(String[] args) {
         new SpringApplicationBuilder(Main.class).run(args);
     }
+
 }

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/application-init-script.yaml
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/application-init-script.yaml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    clickhouse:
+      jdbc-url: jdbc:clickhouse://<host>:<port>
+
+testcontainers:
+  clickhouse:
+    init-script: db/init-script.sql
+    custom-path: "spring.datasource.clickhouse"

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/application-static-port.yaml
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/application-static-port.yaml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     clickhouse:
-        jdbc-url: jdbc:clickhouse://<host>:5001
+      jdbc-url: jdbc:clickhouse://<host>:5001
 
 testcontainers:
-        clickhouse:
-            custom-path: "spring.datasource.clickhouse"
+  clickhouse:
+    custom-path: "spring.datasource.clickhouse"

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/application-test.yaml
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/application-test.yaml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     clickhouse:
-        jdbc-url: jdbc:clickhouse://<host>:<port>
+      jdbc-url: jdbc:clickhouse://<host>:<port>
 
 testcontainers:
-        clickhouse:
-            custom-path: "spring.datasource.clickhouse"
+  clickhouse:
+    custom-path: "spring.datasource.clickhouse"

--- a/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/db/init-script.sql
+++ b/infobip-clickhouse-testcontainers-spring-boot-starter/src/test/resources/db/init-script.sql
@@ -1,0 +1,8 @@
+CREATE TABLE test_table
+(
+    id Int32,
+    name String
+) ENGINE = MergeTree() ORDER BY id;
+
+INSERT INTO test_table (id, name)
+VALUES (1, 'Test');

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/mssql/DatabaseCreator.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/mssql/DatabaseCreator.java
@@ -36,7 +36,6 @@ class DatabaseCreator {
     }
 
     private String getDatabaseUrlPattern(String url) {
-
         if (url.startsWith("jdbc:jtds")) {
             return "(?<jdbcBaseUrl>.*)/(?<databaseName>[^;]*);?(?<otherParameters>.*)";
         }
@@ -44,7 +43,7 @@ class DatabaseCreator {
         return "(?<jdbcBaseUrl>.*);database=(?<databaseName>[^;]*)(?<otherParameters>;.*)?";
     }
 
-    void createDatabaseIfItDoesntExist() {
+    void createDatabaseIfItDoesNotExist() {
         if(!databaseExists()) {
             template.execute(createDatabaseQuery);
         }

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithInitScriptTest.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithInitScriptTest.java
@@ -1,0 +1,50 @@
+package com.infobip.testcontainers.spring.mssql;
+
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@AllArgsConstructor
+@ActiveProfiles("init-script")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = Main.class)
+class MSSQLServerContainerInitializerWithInitScriptTest {
+
+    private final DataSourceProperties properties;
+
+    @Test
+    void shouldCreateDatabase() {
+        // given
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(new SimpleDriverDataSource(
+                getDriver(properties.getUrl()),
+                properties.getUrl(),
+                properties.getUsername(),
+                properties.getPassword()));
+
+        // when
+        String actual = jdbcTemplate.queryForObject("SELECT TOP 1 name FROM test_table", String.class);
+
+        // then
+        then(actual).isEqualTo("Test");
+    }
+
+    private Driver getDriver(String jdbcUrl) {
+        try {
+            return DriverManager.getDriver(jdbcUrl);
+        } catch (SQLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+}

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithJtdsDriverTest.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithJtdsDriverTest.java
@@ -23,7 +23,6 @@ class MSSQLServerContainerInitializerWithJtdsDriverTest {
 
     @Test
     void shouldCreateDatabase() {
-
         // given
         JdbcTemplate jdbcTemplate = new JdbcTemplate(new SimpleDriverDataSource(
                 getDriver(properties.getUrl()),
@@ -45,4 +44,5 @@ class MSSQLServerContainerInitializerWithJtdsDriverTest {
             throw new IllegalArgumentException(e);
         }
     }
+
 }

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithMicrosoftDriverTest.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithMicrosoftDriverTest.java
@@ -25,7 +25,6 @@ class MSSQLServerContainerInitializerWithMicrosoftDriverTest {
 
     @Test
     void shouldCreateContainer() {
-
         // given
         JdbcTemplate jdbcTemplate = new JdbcTemplate(new SimpleDriverDataSource(
                 getDriver(properties.getUrl()),
@@ -42,7 +41,6 @@ class MSSQLServerContainerInitializerWithMicrosoftDriverTest {
 
     @Test
     void shouldInsertUsername() {
-
         // when
         String actual = properties.getUsername();
 
@@ -52,7 +50,6 @@ class MSSQLServerContainerInitializerWithMicrosoftDriverTest {
 
     @Test
     void shouldInsertPassword() {
-
        // when
         String actual = properties.getPassword();
 

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithStaticPortTest.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithStaticPortTest.java
@@ -15,7 +15,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestConstructor;
-import org.testcontainers.Testcontainers;
 
 @AllArgsConstructor
 @ActiveProfiles("static-port")

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/Main.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/Main.java
@@ -9,4 +9,5 @@ public class Main {
     public static void main(String[] args) {
         new SpringApplicationBuilder(Main.class).run(args);
     }
+
 }

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/resources/application-init-script.yaml
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/resources/application-init-script.yaml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:jtds:sqlserver://<host>:<port>/JtdsTestDatabase
+
+testcontainers:
+  mssql:
+    init-script: db/init-script.sql

--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/resources/db/init-script.sql
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/resources/db/init-script.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE JtdsTestDatabase;
+
+USE JtdsTestDatabase;
+
+CREATE TABLE test_table (
+    id INT PRIMARY KEY IDENTITY(1,1),
+    name VARCHAR(4) NOT NULL
+);
+
+INSERT INTO test_table (name)
+VALUES ('Test');

--- a/infobip-postgresql-testcontainers-spring-boot-starter/pom.xml
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/pom.xml
@@ -9,11 +9,6 @@
 
 	<artifactId>infobip-postgresql-testcontainers-spring-boot-starter</artifactId>
 
-	<properties>
-		<!-- DEPENDENCY VERSIONS -->
-		<mssqlserver.version>1.9.1</mssqlserver.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializer.java
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializer.java
@@ -27,6 +27,8 @@ public class PostgreSQLContainerInitializer extends InitializerBase<PostgreSQLCo
                                                        .map(imageName -> new PostgreSQLContainerWrapper(database, imageName))
                                                        .orElseGet(() -> new PostgreSQLContainerWrapper(database));
 
+        Optional.ofNullable(environment.getProperty("testcontainers.postgresql.init-script")).ifPresent(container::withInitScript);
+
         resolveStaticPort(dataSourceUrl, GENERIC_URL_WITH_PORT_GROUP_PATTERN)
             .ifPresent(staticPort -> bindPort(container, staticPort, PostgreSQLContainerWrapper.POSTGRESQL_PORT));
 

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerWrapper.java
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/main/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerWrapper.java
@@ -4,11 +4,12 @@ public class PostgreSQLContainerWrapper
         extends org.testcontainers.containers.PostgreSQLContainer<PostgreSQLContainerWrapper> {
 
     public PostgreSQLContainerWrapper(String databaseName) {
-        this(databaseName, IMAGE + ":" +DEFAULT_TAG);
+        this(databaseName, IMAGE + ":" + DEFAULT_TAG);
     }
 
     public PostgreSQLContainerWrapper(String databaseName, String dockerImageName) {
         super(dockerImageName);
         withDatabaseName(databaseName);
     }
+
 }

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/Main.java
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/Main.java
@@ -9,4 +9,5 @@ public class Main {
     public static void main(String[] args) {
         new SpringApplicationBuilder(Main.class).run(args);
     }
+
 }

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializerTest.java
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializerTest.java
@@ -23,7 +23,6 @@ class PostgreSQLContainerInitializerTest {
 
     @Test
     void shouldCreateContainer() {
-
         // given
         JdbcTemplate jdbcTemplate = new JdbcTemplate(new SimpleDriverDataSource(
                 getDriver(properties.getUrl()),
@@ -45,4 +44,5 @@ class PostgreSQLContainerInitializerTest {
             throw new IllegalArgumentException(e);
         }
     }
+
 }

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializerWithInitScriptTest.java
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializerWithInitScriptTest.java
@@ -1,0 +1,50 @@
+package com.infobip.testcontainers.spring.postgresql;
+
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@AllArgsConstructor
+@ActiveProfiles("init-script")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = Main.class)
+class PostgreSQLContainerInitializerWithInitScriptTest {
+
+    private final DataSourceProperties properties;
+
+    @Test
+    void shouldCreateContainerWithInitScript() {
+        // given
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(new SimpleDriverDataSource(
+                getDriver(properties.getUrl()),
+                properties.getUrl(),
+                properties.getUsername(),
+                properties.getPassword()));
+
+        // when
+        String actual = jdbcTemplate.queryForObject("SELECT name FROM test_table FETCH FIRST ROW ONLY;", String.class);
+
+        // then
+        then(actual).isEqualTo("Test");
+    }
+
+    private Driver getDriver(String jdbcUrl) {
+        try {
+            return DriverManager.getDriver(jdbcUrl);
+        } catch (SQLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+}

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializerWithStaticPortTest.java
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/postgresql/PostgreSQLContainerInitializerWithStaticPortTest.java
@@ -55,4 +55,5 @@ class PostgreSQLContainerInitializerWithStaticPortTest {
             throw new IllegalArgumentException(e);
         }
     }
+
 }

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/test/resources/application-init-script.yaml
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/test/resources/application-init-script.yaml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://<host>:<port>/
+    username: test
+    password: test
+
+testcontainers:
+  postgresql:
+    init-script: db/init-script.sql

--- a/infobip-postgresql-testcontainers-spring-boot-starter/src/test/resources/db/init-script.sql
+++ b/infobip-postgresql-testcontainers-spring-boot-starter/src/test/resources/db/init-script.sql
@@ -1,0 +1,7 @@
+CREATE TABLE test_table(
+    id serial PRIMARY KEY,
+    name VARCHAR(4) NOT NULL
+);
+
+INSERT INTO test_table(id, name)
+VALUES (1, 'Test');

--- a/infobip-testcontainers-common/src/main/java/com/infobip/testcontainers/InitializerBase.java
+++ b/infobip-testcontainers-common/src/main/java/com/infobip/testcontainers/InitializerBase.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationListener;
@@ -53,9 +52,8 @@ public abstract class InitializerBase<C extends Startable>
 
     protected Optional<Integer> resolveStaticPort(Collection<String> connectionStrings, Pattern urlPatternWithPortGroup) {
         return connectionStrings.stream()
-                                .flatMap(connectionString -> resolveStaticPort(connectionString, urlPatternWithPortGroup)
-                                    .map(Stream::of)
-                                    .orElseGet(Stream::empty))
+                                .flatMap(connectionString -> resolveStaticPort(connectionString,
+                                        urlPatternWithPortGroup).stream())
                                 .findFirst();
     }
 


### PR DESCRIPTION
Added support for `testcontainers.db-name.init-script` property where the user can specify the SQL script to be executed on container boot. Examples visible through tests.

Changes:
- Added the `testcontainers.db-name.init-script` property to all the database starters
- Added tests to cover the new feature
- Fixed inconsistent formatting & typos in various places
- Uplift clickhouse driver version
- Removed redundant property from PostgreSQL starter
- Fixed & expanded README.md