### PR TITLE
fixed static mssql port mapping and added test to check mapping

### DIFF
--- a/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithStaticPortTest.java
+++ b/infobip-mssql-testcontainers-spring-boot-starter/src/test/java/com/infobip/testcontainers/spring/mssql/MSSQLServerContainerInitializerWithStaticPortTest.java
@@ -19,6 +19,7 @@ class MSSQLServerContainerInitializerWithStaticPortTest extends TestBase {
 
     private final Environment environment;
     private final DataSourceProperties properties;
+    private final MSSQLServerContainerWrapper mSSQLServerContainerWrapper;
 
     @Test
     void shouldCreateContainer() {
@@ -69,5 +70,22 @@ class MSSQLServerContainerInitializerWithStaticPortTest extends TestBase {
         } catch (SQLException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    @Test
+    void shouldBindContainerToStaticPort() {
+        // when
+        String jdbcUrl = environment.getProperty("spring.datasource.url");
+        String r2dbcUrl = environment.getProperty("spring.r2dbc.url");
+        String flywayUrl = environment.getProperty("spring.flyway.url");
+
+        // then
+        then(jdbcUrl).contains("localhost:5003");
+        then(r2dbcUrl).contains("localhost:5003");
+        then(flywayUrl).contains("localhost:5003");
+
+        then(mSSQLServerContainerWrapper.getPortBindings())
+                .hasSize(1)
+                .contains("5003:1433/tcp");
     }
 }

--- a/infobip-testcontainers-common/src/main/java/com/infobip/testcontainers/InitializerBase.java
+++ b/infobip-testcontainers-common/src/main/java/com/infobip/testcontainers/InitializerBase.java
@@ -18,7 +18,7 @@ public abstract class InitializerBase<C extends Startable>
     public static final String PORT_PLACEHOLDER = "<port>";
     public static final String HOST_PLACEHOLDER = "<host>";
 
-    protected static final Pattern GENERIC_URL_WITH_PORT_GROUP_PATTERN = Pattern.compile(".*://.*:(\\d+)(/.*)?");
+    protected static final Pattern GENERIC_URL_WITH_PORT_GROUP_PATTERN = Pattern.compile(".*://.*:(\\d+)([/;].*)?");
 
     private final AtomicReference<C> container = new AtomicReference<>();
 


### PR DESCRIPTION
[/;] has been added to GENERIC_URL_WITH_PORT_GROUP_PATTERN regex to properly resolve both host:port/ and host:port; datasource formats. shouldBindContainerToStaticPort test has been added to validate mapping of static port works as expected. (note: in existing tests value of actual is full datasource url, so tests check that datasource urls have "localhost:5003", not that port is properly mapped)